### PR TITLE
Allow overbooking of parent tickets to ensure child tickets can booked

### DIFF
--- a/test/unit/tickets/models/TicketModel.js
+++ b/test/unit/tickets/models/TicketModel.js
@@ -11,6 +11,13 @@ describe('TicketModel', () => {
       am.totalApplications = 1;
       expect(am.hasCapacityFor(2)).to.be.true;
     });
+    it('should return true if the ticket is a parent ticket, even if overbooked', () => {
+      const am = new TicketModel();
+      am.quantity = 1;
+      am.totalApplications = 2;
+      am.type = 'parent-guardian';
+      expect(am.hasCapacityFor(1)).to.be.true;
+    });
     it('should throw an error on overflow', () => {
       const am = new TicketModel();
       am.quantity = 3;

--- a/tickets/models/TicketModel.js
+++ b/tickets/models/TicketModel.js
@@ -40,7 +40,9 @@ class TicketModel extends Model {
   }
 
   hasCapacityFor(qty) {
-    if (this.totalApplications + qty <= this.quantity) {
+    // We're getting rid of parent tickets in the future, and there should be enough parent tickets
+    // to cover all ninjas going anyway, so we're just going to let parent tickets be overbooked
+    if (this.type === TicketModel.TYPES.PARENT || this.totalApplications + qty <= this.quantity) {
       return true;
     }
     throw notEnoughCapacityError;


### PR DESCRIPTION
Since the grand scheme of things has us killing off parent tickets going forward, and each event _should_ have enough parent tickets to cover the children coming, we're allowing booking of parent tickets regardless of the quantity specified.

In general, this shouldn't affect many, but it does prevent issues when parent tickets have a lower number available than child tickets.